### PR TITLE
Replace whole lodash with lodash.isplainobject to reduce build size

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -1,5 +1,5 @@
 import { CancelToken } from 'axios'
-import _ from 'lodash'
+import isPlainObject from 'lodash.isplainobject'
 
 function createRequestKey(url, params) {
   let requestKey = url;
@@ -13,7 +13,7 @@ function createStringFromParameters(obj) {
   const keysArr = [];
   for (const key in obj) {
     keysArr.push(key);
-    if (_.isPlainObject(obj[key])) {
+    if (isPlainObject(obj[key])) {
       keysArr.push(createStringFromParameters(obj[key]));
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -644,6 +644,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.5.2",
-    "lodash": "^4.17.15"
+    "lodash.isplainobject": "^4.0.6"
   }
 }


### PR DESCRIPTION
According to [this](https://github.com/mvertopoulos/nuxt-axios-duplicate-blocker/issues/2) issue by suasti, I try to fix it in order to reduce the bundled build size.